### PR TITLE
Unable to use the gem due to it trying to read version.txt

### DIFF
--- a/lib/email_address_validator.rb
+++ b/lib/email_address_validator.rb
@@ -2,7 +2,6 @@ module EmailAddressValidator
   # :stopdoc:
   LIBPATH = ::File.expand_path(::File.dirname(__FILE__)) + ::File::SEPARATOR
   PATH = ::File.dirname(LIBPATH) + ::File::SEPARATOR
-  VERSION = ::File.read(PATH + 'version.txt').strip
   # :startdoc:
 
   # Returns the library path for the module. If any arguments are given,


### PR DESCRIPTION
I'm assuming this was just missed as a part of 8fc8d97137cf1231ed52a05688a23ef67f3b537e

```
ruby-1.9.2-p180 :001 > require 'email_address_validator'
Errno::ENOENT: No such file or directory - /Users/tbishop/.rvm/gems/ruby-1.9.2-p180@instantqnotify/gems/email_address_validator-0.0.2/version.txt
    from /Users/tbishop/.rvm/gems/ruby-1.9.2-p180@instantqnotify/gems/email_address_validator-0.0.2/lib/email_address_validator.rb:5:in `read'
    from /Users/tbishop/.rvm/gems/ruby-1.9.2-p180@instantqnotify/gems/email_address_validator-0.0.2/lib/email_address_validator.rb:5:in `<module:EmailAddressValidator>'
    from /Users/tbishop/.rvm/gems/ruby-1.9.2-p180@instantqnotify/gems/email_address_validator-0.0.2/lib/email_address_validator.rb:1:in `<top (required)>'
    from (irb):1:in `require'
    from (irb):1
    from /Users/tbishop/.rvm/rubies/ruby-1.9.2-p180/bin/irb:16:in `<main>'
ruby-1.9.2-p180 :002 > 
```
